### PR TITLE
add a Slack publisher

### DIFF
--- a/alarmageddon/publishing/slack.py
+++ b/alarmageddon/publishing/slack.py
@@ -53,7 +53,7 @@ class SlackPublisher(Publisher):
         return "Slack: {}".format(self.hook_url)
 
     def send(self, result):
-        """sends a result to Slack inf the result is a faliure."""
+        """sends a result to Slack if the result is a faliure."""
         if result.is_failure() and self.will_publish(result):
 
             message = "(failed) Failure in {0}\nTest:{1}\nFailed because: {2}"
@@ -70,7 +70,7 @@ class SlackPublisher(Publisher):
             self._send_to_slack(message_text)
 
     def send_batch(self, results):
-        """Send a batch of results to HipChat.
+        """Send a batch of results to Slack.
 
         Collapses similar failures together to save space.
         """

--- a/alarmageddon/publishing/slack.py
+++ b/alarmageddon/publishing/slack.py
@@ -1,0 +1,152 @@
+"""Support for publishing to Slack"""
+
+import os
+import requests
+import json
+import collections
+
+from alarmageddon.publishing.publisher import Publisher
+from alarmageddon.publishing.exceptions import PublishFailure
+
+fallback_text = "There were Alarmageddon failures"
+
+
+def _get_collapsed_message(results):
+    """Helper function to collapse similar failures together.
+
+    If several results have the same reason for failing, combine the
+    results to save space and cognitive load on users.
+
+    :param results: List of result objects.
+
+    """
+    description = results[0].description()
+    names = [result.test_name() for result in results]
+    message = ("(failed) {0}\nDescription: {1}").format(", ".join(names),
+                                                        description)
+    return message
+
+
+class SlackPublisher(Publisher):
+    """A Publisher that sends results to Slack.
+
+    Publishes all failures to the provided Slack room.
+
+    :param hook_url: The Slack Hook URL
+    :param priority_threshold: Will publish validations of this priority or
+      higher.
+
+    """
+
+    def __init__(self, hook_url, environment, priority_threshold=None):
+        if not hook_url:
+            raise ValueError("hook_url parameter is required")
+        if not environment:
+            raise ValueError("environment parameter is required")
+
+        super(SlackPublisher, self).__init__("Slack", priority_threshold)
+
+        self._hook_url = hook_url
+        self._environment = environment
+
+    def __str__(self):
+        return "Slack: {}".format(self.hook_url)
+
+    def send(self, result):
+        """sends a result to Slack inf the result is a faliure."""
+        if result.is_failure() and self.will_publish(result):
+
+            message = "(failed) Failure in {0}\nTest:{1}\nFailed because: {2}"
+            .format(
+                self._environment,
+                result.test_name(),
+                result.description())
+
+            message_text = self._build_message(
+                fallback_text,
+                self._get_jenkins_job_url(),
+                message)
+
+            self._send_to_slack(message_text)
+
+    def send_batch(self, results):
+        """Send a batch of results to HipChat.
+
+        Collapses similar failures together to save space.
+        """
+        collapsed = collections.defaultdict(list)
+        errors = 0
+        for result in results:
+            if result.is_failure() and self.will_publish(result):
+                collapsed[result.description()].append(result)
+                errors += 1
+        if errors == 0:
+            return
+        message = "{0} failure(s) in {1}:\n".format(errors, self._environment)
+        message += "\n".join(_get_collapsed_message(collapsed_result)
+                             for collapsed_result in collapsed.itervalues())
+
+        message_text = self._build_message(
+            fallback_text,
+            self._get_jenkins_job_url(),
+            message)
+
+        self._send_to_slack(message_text)
+
+    def _build_message(self, fallback_text, run_link, text):
+        pretext = "Alarmageddon run completed."
+        if run_link is not None:
+            pretext = "{} <{}|View Result>".format(pretext, run_link)
+
+        payload = {
+            "attachments": [
+                {
+                    "fallback": fallback_text,
+                    "author_name": "Alarmageddon",
+                    "color": "danger",
+                    "pretext": pretext,
+                    "text": text,
+                    "mrkdwn": True
+                }
+            ]
+        }
+
+        return payload
+
+    def _send_to_slack(self, message):
+        """Send a message to Slack.
+
+        :param message: The message to be published.
+
+        """
+        headers = {
+            "Context-Type": "application/json"
+        }
+
+        data = json.dumps(message)
+        print "Posting to slack {}".format(data)
+        resp = requests.post(self._hook_url, data=data, headers=headers)
+
+        if resp.status_code < 200 or resp.status_code >= 300:
+            raise PublishFailure(self, "{0} - {1}".format(message, resp.text))
+
+    def _get_jenkins_job_url(self):
+        """If we're running in jenkins use enviroment vars to
+        construct a job url. If we are not in running in jenkins
+        return None
+
+        """
+
+        jenkins_host = os.environ.get('JENKINS_URL')
+
+        if jenkins_host is not None:
+            jenkins_job = os.environ.get('JOB_NAME')
+            jenkins_build = os.environ.get('BUILD_ID')
+            job_url = "{}job/{}/{}/console".format(
+                jenkins_host,
+                jenkins_job,
+                jenkins_build
+            )
+            return job_url
+        else:
+            return None

--- a/doc/alarmageddon.publishing.rst
+++ b/doc/alarmageddon.publishing.rst
@@ -36,6 +36,14 @@ alarmageddon.publishing.hipchat module
     :undoc-members:
     :show-inheritance:
 
+alarmageddon.publishing.slack module
+--------------------------------------
+
+.. automodule:: alarmageddon.publishing.slack
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 alarmageddon.publishing.http module
 -----------------------------------
 
@@ -43,7 +51,7 @@ alarmageddon.publishing.http module
     :members:
     :undoc-members:
     :show-inheritance:
-       
+
 alarmageddon.publishing.pagerduty module
 ----------------------------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,6 +33,7 @@ Features
 * Report failed verifications to
 
   * HipChat
+  * Slack
   * PagerDuty
   * Graphite
   * Email
@@ -65,4 +66,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/doc/publishers.rst
+++ b/doc/publishers.rst
@@ -1,7 +1,7 @@
 Publishers
 ==========
 
-All publishers accept a ``priority_threshold`` argument. This should be one of ``Priority.LOW``, ``Priority.NORMAL``, or ``Priority.CRITICAL``. 
+All publishers accept a ``priority_threshold`` argument. This should be one of ``Priority.LOW``, ``Priority.NORMAL``, or ``Priority.CRITICAL``.
 A publisher will only publish failing validations if they are at least as critical as the ``priority_threshold``. For example, to report on all failures, you should set your publisher's ``priority_threshold`` to ``Priority.LOW``.
 
 JUnit XML
@@ -17,6 +17,17 @@ The HipChat publisher will report failures to your hipchat room::
     HipChatPublisher("hipchat.route.here","token","stable","hipchat_room")
 
 By default, the HipChat publisher alerts on failures of NORMAL priority or higher.
+
+Slack
+-------
+
+The Slack publisher will report failures to your slack channel::
+
+    SlackPublisher("hook.url","stable")
+
+``hook.url`` should be a slack `incoming web hook <https://my.slack.com/services/new/incoming-webhook/>`_ integration
+to the channel that should be published to.
+By default, the Slack publisher alerts on failures of NORMAL priority or higher.
 
 Http
 ----
@@ -55,7 +66,7 @@ There are two email publishers. SimpleEmailPublisher provides basic emailing fun
 EmailPublisher provides more granular control over the sent messages. For this reason, validations that will be published by the email publisher must be enriched with extra information.
 
 To create an email publisher, you need a config object with the appropriate values in it, and optionally a set of defaults for missing config values::
-  
+
   email_pub = EmailPublisher(config, defaults=general_defaults)
 
 For enrichment, a convenience method is provided in emailer to ensure that the appropriate value are present::
@@ -64,4 +75,3 @@ For enrichment, a convenience method is provided in emailer to ensure that the a
 
 .. note::
   For the email publisher to publish a failure, the priority threshold must be reached **and** the validation must be enriched.
-

--- a/tests/publishing/test_slack.py
+++ b/tests/publishing/test_slack.py
@@ -1,0 +1,61 @@
+from alarmageddon.publishing.slack import SlackPublisher
+from alarmageddon.result import Failure
+from alarmageddon.result import Success
+from alarmageddon.publishing.exceptions import PublishFailure
+from alarmageddon.validations.validation import Validation, Priority
+import pytest
+
+
+#Successes aren't sent, so monkeypatch out post and then
+#only failures should notice
+@pytest.fixture
+def no_post(monkeypatch):
+    monkeypatch.delattr("requests.post")
+
+
+def new_publisher():
+    return SlackPublisher(
+        hook_url="fakeurl",
+        environment="UnitTest")
+
+
+def test_requires_hook_url():
+    with pytest.raises(ValueError):
+        SlackPublisher(hook_url="",
+                         environment="UnitTest")
+
+
+def test_requires_environment():
+    with pytest.raises(ValueError):
+        SlackPublisher(hook_url="fakeurl",
+                         environment="")
+
+
+def test_repr():
+    slack = new_publisher()
+    slack.__repr__()
+
+
+def testSendSuccess(no_post, monkeypatch):
+    slack = new_publisher()
+    v = Validation("low", priority=Priority.LOW)
+    success = Success("bar", v)
+    slack.send(success)
+
+
+def testSendFailure(no_post, monkeypatch):
+    slack = new_publisher()
+    v = Validation("low", priority=Priority.LOW)
+    failure = Failure("foo", v, "unable to frobnicate")
+    with pytest.raises(AttributeError):
+        slack.send(failure)
+
+
+def test_publish_failure(httpserver):
+    httpserver.serve_content(code=500, headers={"content-type": "text/plain"},
+                             content='{"mode":"NORMAL"}')
+    pub = SlackPublisher(httpserver.url, "env")
+    v = Validation("low", priority=Priority.CRITICAL)
+    failure = Failure("bar", v, "message")
+    with pytest.raises(PublishFailure):
+        pub.send(failure)


### PR DESCRIPTION
#### What's this PR do?
Adds a [Slack](https://slack.com/) publisher 
#### Where should the reviewer start?
`alarmageddon/publishing/slack.py`
#### How should this be manually tested?
run `scripts/test`
#### Any background context you want to provide?
This PR adds a Slack publisher. This publisher was molded after the hipchat publisher. 
I also ran a pep8 linter to ensure style correctness. 
#### Screenshots (if appropriate)
<img width="437" alt="screen shot 2015-08-21 at 10 59 35 am" src="https://cloud.githubusercontent.com/assets/270735/9414184/c7597600-47f3-11e5-9cd7-1743fc3052ed.png">

#### Were the tests updated?
yes
