### PR TITLE
[Feature] add ability to wildcard arrays in json expectation

### DIFF
--- a/alarmageddon/validations/json_expectations.py
+++ b/alarmageddon/validations/json_expectations.py
@@ -73,7 +73,10 @@ class ExpectedJsonValueLessThan(ExpectedJsonPredicate):
         ExpectedJsonPredicate.__init__(self, json_property_path, value)
 
     def validate_value(self, validation, expected_value, actual_value):
-        if actual_value is None:
+        if type(actual_value) is list:
+            validation.fail(
+                "cannot use array wildcard with less than assertion")
+        elif actual_value is None:
             validation.fail(
                 "missing JSON property {0}".format(self.json_property_path))
         elif float(actual_value) >= float(expected_value):
@@ -93,7 +96,10 @@ class ExpectedJsonValueGreaterThan(ExpectedJsonPredicate):
         ExpectedJsonPredicate.__init__(self, json_property_path, value)
 
     def validate_value(self, validation, expected_value, actual_value):
-        if actual_value is None:
+        if type(actual_value) is list:
+            validation.fail(
+                "cannot use array wildcard with less than assertion")
+        elif actual_value is None:
             validation.fail(
                 "missing JSON property {0}".format(self.json_property_path))
         elif float(actual_value) <= float(expected_value):

--- a/alarmageddon/validations/json_expectations.py
+++ b/alarmageddon/validations/json_expectations.py
@@ -48,10 +48,20 @@ class ExpectedJsonEquality(ExpectedJsonPredicate):
         ExpectedJsonPredicate.__init__(self, json_property_path, value)
 
     def validate_value(self, validation, expected_value, actual_value):
-        if not actual_value or actual_value != expected_value:
-            validation.fail(
-                "expected JSON property {0} to be '{1}', actual value: '{2}'"
-                .format(self.json_property_path, expected_value, actual_value))
+        if type(actual_value) is list:
+            if expected_value not in actual_value:
+                validation.fail(
+                    ("expected JSON property {0}"
+                     " to contain '{1}', actual value: '{2}'")
+                    .format(
+                        self.json_property_path, expected_value, actual_value))
+        else:
+            if not actual_value or actual_value != expected_value:
+                validation.fail(
+                    ("expected JSON property {0}"
+                     " to be '{1}', actual value: '{2}'")
+                    .format(
+                        self.json_property_path, expected_value, actual_value))
 
     def __repr__(self):
         return "{}: {} should be {}".format(type(self).__name__, self.json_property_path, self.value)
@@ -97,7 +107,7 @@ class ExpectedJsonValueGreaterThan(ExpectedJsonPredicate):
         return "{}: {} > {}".format(type(self).__name__, self.json_property_path, self.value)
 
 
-INDEXED_ARRAY = re.compile(r"([^[]+)\[(\d+)\]")
+INDEXED_ARRAY = re.compile(r"([^[]+)\[(\d+|\*)\]")
 
 
 class _JsonQuery(object):
@@ -128,8 +138,13 @@ class _JsonQuery(object):
                     # We have an array property and the caller has specified
                     # which element of the array to validate against
                     name = match.group(1)
-                    index = int(match.group(2))
-                    root = root[name][index]
+                    if match.group(2) == "*":
+                        # caller has supplied a wildcard
+                        # return the list element
+                        root = root[name]
+                    else:
+                        index = int(match.group(2))
+                        root = root[name][index]
                 else:
                     root = root[path_elem]
         except Exception:

--- a/doc/validations.rst
+++ b/doc/validations.rst
@@ -40,7 +40,16 @@ An example of expectations on HttpValidations, where we expect to get either a 2
 
     validation = HttpValidation.get("url")
     validation.expect_status_codes([200,404])
-    validation.expect_json_property("json.path.to.value","expected")
+    validation.expect_json_property_value("json.path.to.value","expected")
+
+``expect_json_property_value`` accepts query string that allows you to pluck values from json. Consider the following json document
+
+    {"abc": "123", "another": {"nested": "entry"}, "alpha": {"array": [1, 2, 3, 4]}}
+
+``abc`` will reference ``"123"``
+``another.nested`` will reference ``"entry"``
+``array[4]`` will reference ``4``
+``array[*]`` will reference ``[1, 2, 3, 4]`` 
 
 SSH
 -------------

--- a/tests/test_json_expectations.py
+++ b/tests/test_json_expectations.py
@@ -40,6 +40,13 @@ def test_json_less_than():
     exp.validate_value(validation, 5, 3)
 
 
+def test_json_less_than_wildcard():
+    validation = HttpValidation.get("url")
+    exp = ExpectedJsonValueLessThan("path[*]", [1, 2, 3])
+    with pytest.raises(ValidationFailure):
+        exp.validate_value(validation, 1, [1, 2, 3])
+
+
 def test_json_less_than_fails():
     validation = HttpValidation.get("url")
     exp = ExpectedJsonValueLessThan("path", 5)
@@ -51,6 +58,13 @@ def test_json_greater_than():
     validation = HttpValidation.get("url")
     exp = ExpectedJsonValueGreaterThan("path", 5)
     exp.validate_value(validation, 5, 7)
+
+
+def test_json_greater_than_wildcard():
+    validation = HttpValidation.get("url")
+    exp = ExpectedJsonValueGreaterThan("path[*]", [1, 2, 3])
+    with pytest.raises(ValidationFailure):
+        exp.validate_value(validation, 1, [1, 2, 3])
 
 
 def test_json_greater_than_fails():

--- a/tests/test_json_expectations.py
+++ b/tests/test_json_expectations.py
@@ -21,6 +21,12 @@ def test_json_equality():
     exp.validate_value(validation, 5, 5)
 
 
+def test_json_wildcard_equality():
+    validation = HttpValidation.get("url")
+    exp = ExpectedJsonEquality("path[*]", [1, 2, 3])
+    exp.validate_value(validation, 2, [1, 2, 3])
+
+
 def test_json_equality_fails():
     validation = HttpValidation.get("url")
     exp = ExpectedJsonEquality("path", 5)
@@ -71,6 +77,13 @@ def test_json_query_array():
             "alpha": {"array": [1, 2, 3, 4]}}
     result = _JsonQuery.find(json, "alpha.array[2]")
     assert result == 3
+
+
+def test_json_wildcard_query_array():
+    json = {"abc": "123", "another": {"nested": "entry"},
+            "alpha": {"array": [1, 2, 3, 4]}}
+    result = _JsonQuery.find(json, "alpha.array[*]")
+    assert result == [1, 2, 3, 4]
 
 
 def test_validate():


### PR DESCRIPTION
#### What's this PR do?
Adds the ability to use a wildcard for an array index when using json expectations. 
Now you can do
```python
HttpValidation.get("http://localhost/users").expect_json_property_value("users[*]", "Stephen")
```
#### Where should the reviewer start?
alarmageddon/validations/json_expectations.py
#### How should this be manually tested?
`scripts/install`
#### Any background context you want to provide?
Ran into a issue where a REST API I was testing didn't always preserve order when presenting json arrays.
Sometimes you would get 
```javascript
{ "users":["Tim", "Scott"] }
```
others you'd get
```javascript
{ "users":["Scott", "Tim"]}
```
This made using the json_expectations unreliable. The wildcard helps to alleviate this issue
#### Were the tests updated?
added a couple of tests for this functionality. For some reason `scripts/install` wouldn't work on my machine but `.venv/bin/py.test -s tests/test_json_expectations.py` worked like a charm. 
