### PR TITLE
Python 3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ An automated service monitoring tool that reports failures to:
 
 Alarmageddon can monitor services via HTTP and/or SSH.
 
+Alarmageddon supports Python 2.7 and Python 3.4+
+
 HTML documentation can be found on [Read the Docs](http://alarmageddon.readthedocs.org/en/latest/example.html).
 
 ```python
@@ -40,6 +42,7 @@ Alarmageddon can be installed via pip:
 ```shell
 pip install alarmageddon
 ```
+
 
 Validations
 ======
@@ -104,6 +107,11 @@ Sends emails on test failure. The SimpleEmailPublisher will email the text of th
 
 Changelog
 =========
+
+1.1.0
+* Python3 support
+* Address security vulnerability by upgrading Jinja to 2.10
+* Address security vulnerability by upgrading requests to 2.22
 
 1.0.5
 * Added Microsoft Teams publisher (thanks jestin1005!)

--- a/alarmageddon/banner.py
+++ b/alarmageddon/banner.py
@@ -13,24 +13,24 @@ def print_banner(color=True):
         # Print a color version of the banner
         init()
         print("")
-        print(Fore.WHITE + "     " + Style.DIM + "( " + Style.NORMAL + "." + Style.DIM +  "  (    ) :" + Style.NORMAL + "." + Style.DIM +  " )      " + 
-              Style.NORMAL + Fore.YELLOW + ".  , // .  ,      " + Fore.GREEN + "/\\")
-        print(Fore.WHITE + "      " + Style.DIM + "( (    )     )        " + Style.NORMAL  + Fore.YELLOW + ".  //   .     " + Fore.GREEN + "/\\/  \\/\\")
-        print(Fore.WHITE + "       " + Style.DIM + "(  : " + Style.NORMAL + "*" + Style.DIM +  "  (  )  " + Style.NORMAL + "   *   "  + Fore.YELLOW + 
-              ". //  .      " + Fore.GREEN + "( " + Fore.RED + ">" + Fore.GREEN + "\\  /" + Fore.RED + "<" + Fore.GREEN + " )")
-        print(Fore.WHITE + "  * " + Style.DIM + "    (    :   )         "  + Style.NORMAL + Fore.YELLOW + ". // . .      " + Fore.GREEN + "/  `__`  \\")
-        print(Fore.WHITE + "         " + Style.DIM + "( :  : )   " + Style.NORMAL + " *      "  + Fore.RED + Style.BRIGHT + " O" + Fore.YELLOW + Style.NORMAL + 
-              " .         " + Fore.GREEN + "\\ /" + Fore.WHITE + "VVVV" + Fore.GREEN + "\ /")
-        print(Fore.WHITE + "     * " + Style.DIM + "   ( :  )                        " + Style.NORMAL + Fore.RED + "/" + Fore.WHITE + "IIIIIII" + Fore.RED + 
-              "/[]\\        ")
-        print(Fore.WHITE + "    .      " + Fore.RED + "||||" + Fore.WHITE + "    .                   " + Fore.WHITE + Style.DIM + "d" + Style.NORMAL + Fore.RED + "_" + Fore.WHITE + "O" + Fore.RED +
-              "______" + Fore.WHITE + "O" + Fore.RED + "___" + Style.DIM + Fore.WHITE + "b" + Style.NORMAL)
-        print(Fore.WHITE + "         . " + Fore.RED + "||||" + Fore.WHITE + "  .     \\o/  \\o/      " + Fore.GREEN + " __   \\" + Fore.WHITE + "^^^^" + 
-              Fore.GREEN + "/ \     ")
-        print(Fore.WHITE + "         " + Fore.MAGENTA + "_/ " + Fore.YELLOW + "@ @@" + Fore.MAGENTA + "_" + Fore.WHITE + "       |    |       " + 
-              Fore.GREEN + "/  /\\  \__/   \ ")
-        print(Fore.WHITE + "        " + Fore.MAGENTA + "/  " + Fore.YELLOW + "@   @" + Fore.MAGENTA + " \  " + Fore.WHITE + "   //    \\\\    " + 
-              Fore.GREEN + " " + Fore.WHITE + " VVV" + Fore.GREEN + "\\ \  \      \ " + Fore.RESET)
+        print((Fore.WHITE + "     " + Style.DIM + "( " + Style.NORMAL + "." + Style.DIM +  "  (    ) :" + Style.NORMAL + "." + Style.DIM +  " )      " + 
+              Style.NORMAL + Fore.YELLOW + ".  , // .  ,      " + Fore.GREEN + "/\\"))
+        print((Fore.WHITE + "      " + Style.DIM + "( (    )     )        " + Style.NORMAL  + Fore.YELLOW + ".  //   .     " + Fore.GREEN + "/\\/  \\/\\"))
+        print((Fore.WHITE + "       " + Style.DIM + "(  : " + Style.NORMAL + "*" + Style.DIM +  "  (  )  " + Style.NORMAL + "   *   "  + Fore.YELLOW + 
+              ". //  .      " + Fore.GREEN + "( " + Fore.RED + ">" + Fore.GREEN + "\\  /" + Fore.RED + "<" + Fore.GREEN + " )"))
+        print((Fore.WHITE + "  * " + Style.DIM + "    (    :   )         "  + Style.NORMAL + Fore.YELLOW + ". // . .      " + Fore.GREEN + "/  `__`  \\"))
+        print((Fore.WHITE + "         " + Style.DIM + "( :  : )   " + Style.NORMAL + " *      "  + Fore.RED + Style.BRIGHT + " O" + Fore.YELLOW + Style.NORMAL + 
+              " .         " + Fore.GREEN + "\\ /" + Fore.WHITE + "VVVV" + Fore.GREEN + "\ /"))
+        print((Fore.WHITE + "     * " + Style.DIM + "   ( :  )                        " + Style.NORMAL + Fore.RED + "/" + Fore.WHITE + "IIIIIII" + Fore.RED + 
+              "/[]\\        "))
+        print((Fore.WHITE + "    .      " + Fore.RED + "||||" + Fore.WHITE + "    .                   " + Fore.WHITE + Style.DIM + "d" + Style.NORMAL + Fore.RED + "_" + Fore.WHITE + "O" + Fore.RED +
+              "______" + Fore.WHITE + "O" + Fore.RED + "___" + Style.DIM + Fore.WHITE + "b" + Style.NORMAL))
+        print((Fore.WHITE + "         . " + Fore.RED + "||||" + Fore.WHITE + "  .     \\o/  \\o/      " + Fore.GREEN + " __   \\" + Fore.WHITE + "^^^^" + 
+              Fore.GREEN + "/ \     "))
+        print((Fore.WHITE + "         " + Fore.MAGENTA + "_/ " + Fore.YELLOW + "@ @@" + Fore.MAGENTA + "_" + Fore.WHITE + "       |    |       " + 
+              Fore.GREEN + "/  /\\  \__/   \ "))
+        print((Fore.WHITE + "        " + Fore.MAGENTA + "/  " + Fore.YELLOW + "@   @" + Fore.MAGENTA + " \  " + Fore.WHITE + "   //    \\\\    " + 
+              Fore.GREEN + " " + Fore.WHITE + " VVV" + Fore.GREEN + "\\ \  \      \ " + Fore.RESET))
         print("")
         print("Alarmageddon: Monitoring Your Stuff...")
         print("    Until You Don't Care About Your Stuff.")

--- a/alarmageddon/publishing/emailer.py
+++ b/alarmageddon/publishing/emailer.py
@@ -9,9 +9,11 @@ from jinja2 import Template, Environment, FileSystemLoader, Undefined
 
 import smtplib
 
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEText import MIMEText
-from email import Utils
+#from email.MIMEMultipart import MIMEMultipart
+#from email.MIMEText import MIMEText
+from six.moves.email_mime_text import MIMEText
+from six.moves.email_mime_multipart import MIMEMultipart
+from email import utils
 
 import logging
 
@@ -196,7 +198,7 @@ class SimpleEmailPublisher(Publisher):
         :param sender: A dictionary containing information about the sender.
 
         """
-        return Utils.formataddr((sender['real_name'], sender['address']))
+        return utils.formataddr((sender['real_name'], sender['address']))
 
     def configure_recipients(self, recipients):
         """Properly formats the list of recipient addresses.
@@ -211,7 +213,7 @@ class SimpleEmailPublisher(Publisher):
         addresses = []
 
         for recipient in recipients:
-            addresses.append(Utils.formataddr((recipient['real_name'],
+            addresses.append(utils.formataddr((recipient['real_name'],
                                                recipient['address'])))
 
         # sendmail requires the recipients to be an array of addresses

--- a/alarmageddon/publishing/emailer.py
+++ b/alarmageddon/publishing/emailer.py
@@ -9,8 +9,6 @@ from jinja2 import Template, Environment, FileSystemLoader, Undefined
 
 import smtplib
 
-#from email.MIMEMultipart import MIMEMultipart
-#from email.MIMEText import MIMEText
 from six.moves.email_mime_text import MIMEText
 from six.moves.email_mime_multipart import MIMEMultipart
 from email import utils

--- a/alarmageddon/publishing/hipchat.py
+++ b/alarmageddon/publishing/hipchat.py
@@ -96,7 +96,7 @@ class HipChatPublisher(Publisher):
             return
         message = "{0} failure(s) in {1}:\n".format(errors, self.environment)
         message += "\n".join(_get_collapsed_message(collapsed_result)
-                             for collapsed_result in collapsed.itervalues())
+                             for collapsed_result in list(collapsed.values()))
         self._send_to_hipchat(message)
 
     def _send_to_hipchat(self, message):

--- a/alarmageddon/publishing/http.py
+++ b/alarmageddon/publishing/http.py
@@ -139,7 +139,7 @@ class HttpPublisher(Publisher):
         """
         if result.is_failure() or self._publish_successes:
             published = False
-            for i in xrange(self._attempts):
+            for i in range(self._attempts):
                 try:
                     response = requests.request(self._get_method(result),
                                                 self._get_url(result),

--- a/alarmageddon/publishing/pagerduty.py
+++ b/alarmageddon/publishing/pagerduty.py
@@ -113,7 +113,7 @@ class PagerDutyPublisher(Publisher):
 
             #exponential backoff
             logger.debug("Sending send {}".format(result))
-            for i in xrange(4):
+            for i in range(4):
                 resp = requests.post(self._api_end_point,
                                      data=data, headers=headers, stream=True)
 

--- a/alarmageddon/publishing/pagerduty.py
+++ b/alarmageddon/publishing/pagerduty.py
@@ -73,7 +73,7 @@ class PagerDutyPublisher(Publisher):
         #and here
         message = str(type(validation)) + str(validation.__dict__)
         hasher = hashlib.md5()
-        hasher.update(message)
+        hasher.update(message.encode('utf-8'))
         pagerduty_id = hasher.hexdigest()
 
         logger.debug("Generated id {} for {}".format(pagerduty_id, result))

--- a/alarmageddon/publishing/publisher.py
+++ b/alarmageddon/publishing/publisher.py
@@ -64,6 +64,9 @@ class Publisher(object):
         :param result: The :py:class:`~.result.TestResult` of a test.
 
         """
+        if self.priority_threshold is None:
+            return True
+
         priority = result.priority
         return self.priority_threshold <= priority
 

--- a/alarmageddon/publishing/slack.py
+++ b/alarmageddon/publishing/slack.py
@@ -91,7 +91,7 @@ class SlackPublisher(Publisher):
             return
         message = "{0} failure(s) in {1}:\n".format(errors, self.environment)
         message += "\n".join(_get_collapsed_message(collapsed_result)
-                             for collapsed_result in collapsed.itervalues())
+                             for collapsed_result in list(collapsed.values()))
 
         message_text = self._build_message(
             FALLBACK_TEXT,

--- a/alarmageddon/publishing/teams.py
+++ b/alarmageddon/publishing/teams.py
@@ -85,7 +85,7 @@ class TeamsPublisher(Publisher):
             return
         message = "{0} failure(s) :\n".format(errors)
         message += "\n".join(_get_collapsed_message(collapsed_result)
-                             for collapsed_result in collapsed.itervalues())
+                             for collapsed_result in list(collapsed.values()))
 
         message_text = self._build_message(
             FALLBACK_TEXT,

--- a/alarmageddon/reporter.py
+++ b/alarmageddon/reporter.py
@@ -48,7 +48,7 @@ class Reporter(object):
             logger.debug("Reporting to {}".format(publisher))
             try:
                 publisher.send_batch(self._reports)
-            except PublishFailure,e:
+            except PublishFailure as e:
                 #we don't want to block other publishers from publishing
                 #so just keep going for now
                 errors.append(e)

--- a/alarmageddon/reporter.py
+++ b/alarmageddon/reporter.py
@@ -1,6 +1,6 @@
 """Reports test results to registered publishers."""
 
-from publishing.exceptions import PublishFailure
+from .publishing.exceptions import PublishFailure
 import logging
 
 logger = logging.getLogger(__name__)

--- a/alarmageddon/run.py
+++ b/alarmageddon/run.py
@@ -196,11 +196,11 @@ def do_dry_run(validations, publishers):
     for publisher in sorted(
             publishers, reverse=True,
             key=lambda x: x.priority_threshold):
-        print("Publisher: %s (threshold: %s)" % (
-            publisher.name(), Priority.string(publisher.priority_threshold)))
+        print(("Publisher: %s (threshold: %s)" % (
+            publisher.name(), Priority.string(publisher.priority_threshold))))
         for validation in dry_run[publisher]:
-            print("   %s (priority: %s)" % (
-                validation.name, Priority.string(validation.priority)))
+            print(("   %s (priority: %s)" % (
+                validation.name, Priority.string(validation.priority))))
 
 
 def _compute_dry_run(validations, publishers):

--- a/alarmageddon/run.py
+++ b/alarmageddon/run.py
@@ -171,7 +171,7 @@ def _perform(validation, immutable_group_failures, results):
         else:
             result = Success(validation.name, validation,
                              time=runtime)
-    except Exception, e:
+    except Exception as e:
         result = Failure(validation.name, validation, str(e),
                          time=time.time() - start)
 

--- a/alarmageddon/run.py
+++ b/alarmageddon/run.py
@@ -195,7 +195,7 @@ def do_dry_run(validations, publishers):
     publishers = list(dry_run.keys())
     for publisher in sorted(
             publishers, reverse=True,
-            key=lambda x: x.priority_threshold):
+            key=lambda x: x.priority_threshold if x.priority_threshold is not None else -1):
         print(("Publisher: %s (threshold: %s)" % (
             publisher.name(), Priority.string(publisher.priority_threshold))))
         for validation in dry_run[publisher]:

--- a/alarmageddon/run.py
+++ b/alarmageddon/run.py
@@ -125,7 +125,7 @@ def _run_validations(validations, reporter, processes=1, timeout=60, timeout_ret
         immutable_group_failures = dict(group_failures)
         results = manager.list()
         for valid in order_set:
-            for i in xrange(timeout_retries):
+            for i in range(timeout_retries):
                 #TODO: parallelize
                 p = multiprocessing.Process(target=_perform, args=(valid, immutable_group_failures, results))
                 p.start()

--- a/alarmageddon/run.py
+++ b/alarmageddon/run.py
@@ -192,7 +192,7 @@ def do_dry_run(validations, publishers):
 
     """
     dry_run = _compute_dry_run(validations, publishers)
-    publishers = dry_run.keys()
+    publishers = list(dry_run.keys())
     for publisher in sorted(
             publishers, reverse=True,
             key=lambda x: x.priority_threshold):

--- a/alarmageddon/validations/cassandra.py
+++ b/alarmageddon/validations/cassandra.py
@@ -393,7 +393,7 @@ class CassandraStatusValidation(SshValidation):
 
     def perform_on_host(self, connection):
         """Runs nodetool status and parses the output."""
-        output = connection.run('nodetool status')
+        output = connection.run('nodetool status', warn=True)
         host = connection.host
 
         if "Exception" in output:

--- a/alarmageddon/validations/cassandra.py
+++ b/alarmageddon/validations/cassandra.py
@@ -1,7 +1,5 @@
 """Convenience Validations for working with Cassandra"""
 
-from fabric.operations import run
-
 from alarmageddon.validations.validation import Priority
 from alarmageddon.validations.ssh import SshValidation
 
@@ -393,9 +391,10 @@ class CassandraStatusValidation(SshValidation):
         self.owns_threshold = owns_threshold
         self.cluster_name = cluster_name
 
-    def perform_on_host(self, host):
+    def perform_on_host(self, connection):
         """Runs nodetool status and parses the output."""
-        output = run('nodetool status')
+        output = connection.run('nodetool status')
+        host = connection.host
 
         if "Exception" in output:
             self.fail_on_host(host, ("An exception occurred while " +

--- a/alarmageddon/validations/cassandra.py
+++ b/alarmageddon/validations/cassandra.py
@@ -132,7 +132,7 @@ class Status(object):
     """An enum-like object that represents the status of a Cassandra Node
 
     """
-    UNKNOWN, UP, DOWN = range(3)
+    UNKNOWN, UP, DOWN = list(range(3))
 
     @staticmethod
     def from_text(text):
@@ -158,7 +158,7 @@ class State(object):
     """An enum-like object that represents the state of a Cassandra Node
 
     """
-    UNKNOWN, NORMAL, LEAVING, JOINING, MOVING = range(5)
+    UNKNOWN, NORMAL, LEAVING, JOINING, MOVING = list(range(5))
 
     @staticmethod
     def from_text(text):

--- a/alarmageddon/validations/graphite.py
+++ b/alarmageddon/validations/graphite.py
@@ -13,6 +13,8 @@ from alarmageddon.validations.graphite_expectations import \
 
 import logging
 
+import six
+
 logger = logging.getLogger(__name__)
 
 
@@ -142,7 +144,7 @@ class GraphiteValidation(Validation):
         if len(chunks) == 2:
             readings = []
             for tok in chunks[1].split(','):
-                if tok == u'None':
+                if tok == six.u('None'):
                     readings.append(None)
                 else:
                     readings.append(float(tok))

--- a/alarmageddon/validations/http.py
+++ b/alarmageddon/validations/http.py
@@ -148,7 +148,7 @@ class HttpValidation(Validation):
 
     def perform(self, group_failures):
         """Perform the HTTP request and validate the response."""
-        for i in xrange(self._retries):
+        for i in range(self._retries):
             logger.debug("Attempt {} for {} {}".format(i, self._method, self._url))
             try:
                 resp = requests.request(

--- a/alarmageddon/validations/http.py
+++ b/alarmageddon/validations/http.py
@@ -1,9 +1,9 @@
 """HTTP Validation"""
 import time
-import urlparse
 import os
 import requests
 import copy
+import six.moves.urllib.parse as urlparse
 
 from alarmageddon.validations.validation import Validation, Priority
 from alarmageddon.validations.json_expectations import \

--- a/alarmageddon/validations/http.py
+++ b/alarmageddon/validations/http.py
@@ -159,7 +159,7 @@ class HttpValidation(Validation):
                 self._elapsed_time = resp.elapsed.total_seconds()
                 self._check_expectations(resp)
                 break
-            except Exception, ex:
+            except Exception as ex:
                 if type(ex) is requests.exceptions.Timeout:
                     self._elapsed_time = self.timeout
                 if i == self._retries - 1:

--- a/alarmageddon/validations/http_expectations.py
+++ b/alarmageddon/validations/http_expectations.py
@@ -77,7 +77,7 @@ class ExpectedHeader(ResponseExpectation):
         if self.name not in response.headers:
             validation.fail("No header named: '{0}'.  Found header names: {1}"
                             .format(self.name,
-                                    ', '.join(response.headers.keys())))
+                                    ', '.join(list(response.headers.keys()))))
         elif self.value != response.headers[self.name]:
             validation.fail(
                 "The value of the '{0}' header is '{1}', expected '{2}'"

--- a/alarmageddon/validations/kafka.py
+++ b/alarmageddon/validations/kafka.py
@@ -71,7 +71,7 @@ class KafkaStatusValidation(SshValidation):
         topics = [parsed[i] for i in range(0, len(parsed), 5)]
         leaders = [parsed[i] for i in range(2, len(parsed), 5)]
 
-        tuples = zip(topics, leaders)
+        tuples = list(zip(topics, leaders))
         duplicates = [x for x, y in Counter(tuples).items() if y > 1]
 
         if len(duplicates) != 0:

--- a/alarmageddon/validations/kafka.py
+++ b/alarmageddon/validations/kafka.py
@@ -55,7 +55,7 @@ class KafkaStatusValidation(SshValidation):
         output = connection.run(
             self.kafka_list_topic_command +
             " --zookeeper " +
-            self.zookeeper_nodes)
+            self.zookeeper_nodes, warn=True)
 
         error_patterns = [
             'No such file', 'Missing required argument', 'Exception']

--- a/alarmageddon/validations/kafka.py
+++ b/alarmageddon/validations/kafka.py
@@ -68,8 +68,8 @@ class KafkaStatusValidation(SshValidation):
                                                              host),
                                              output))
         parsed = re.split(r'\t|\n', output)
-        topics = [parsed[i] for i in xrange(0, len(parsed), 5)]
-        leaders = [parsed[i] for i in xrange(2, len(parsed), 5)]
+        topics = [parsed[i] for i in range(0, len(parsed), 5)]
+        leaders = [parsed[i] for i in range(2, len(parsed), 5)]
 
         tuples = zip(topics, leaders)
         duplicates = [x for x, y in Counter(tuples).items() if y > 1]

--- a/alarmageddon/validations/kafka.py
+++ b/alarmageddon/validations/kafka.py
@@ -72,7 +72,7 @@ class KafkaStatusValidation(SshValidation):
         leaders = [parsed[i] for i in range(2, len(parsed), 5)]
 
         tuples = list(zip(topics, leaders))
-        duplicates = [x for x, y in Counter(tuples).items() if y > 1]
+        duplicates = [x for x, y in list(Counter(tuples).items()) if y > 1]
 
         if len(duplicates) != 0:
             duplicates_str =", ".join("%s has %s" %

--- a/alarmageddon/validations/kafka.py
+++ b/alarmageddon/validations/kafka.py
@@ -1,7 +1,5 @@
 """Convenience Validations for working with Kafka"""
 
-from fabric.operations import run
-
 from alarmageddon.validations.validation import Priority
 from alarmageddon.validations.ssh import SshValidation
 
@@ -51,9 +49,10 @@ class KafkaStatusValidation(SshValidation):
         self.zookeeper_nodes = zookeeper_nodes
         self.cluster_name = cluster_name
 
-    def perform_on_host(self, host):
+    def perform_on_host(self, connection):
         """Runs kafka list topic command on host"""
-        output = run(
+        host = connection.host
+        output = connection.run(
             self.kafka_list_topic_command +
             " --zookeeper " +
             self.zookeeper_nodes)

--- a/alarmageddon/validations/rabbitmq.py
+++ b/alarmageddon/validations/rabbitmq.py
@@ -72,7 +72,7 @@ class RabbitMqValidation(Validation):
         """
         try:
             (conn, chan) = self._connect()
-        except AMQPError, ex:
+        except AMQPError as ex:
             #if we're here we're intentionally ignoring the failure
             return
 
@@ -84,7 +84,7 @@ class RabbitMqValidation(Validation):
                 self.fail("Too many messages in queue ({0} messages)."
                           .format(message_count))
 
-        except AMQPError, ex:
+        except AMQPError as ex:
             self.fail("RabbitMQ exception throw from host: {0}.  {1}"
                       .format(self.rabbitmq_context.host, repr(ex)))
 
@@ -99,7 +99,7 @@ class RabbitMqValidation(Validation):
                 conn = self.rabbitmq_context.get_connection(self.timeout)
                 chan = conn.channel()
                 return (conn, chan)
-            except AMQPError, ex:
+            except AMQPError as ex:
                 if attempt >= self.num_attempts:
                     if self.ignore_connection_failure:
                         raise ex

--- a/alarmageddon/validations/ssh.py
+++ b/alarmageddon/validations/ssh.py
@@ -91,7 +91,7 @@ class SshValidation(Validation):
                           user=self.context.user,
                           key_filename=self.context.key_file):
                 try:
-                    for i in xrange(self.retries + 1):
+                    for i in range(self.retries + 1):
                         try:
                             self.perform_on_host(host)
                             break

--- a/alarmageddon/validations/ssh.py
+++ b/alarmageddon/validations/ssh.py
@@ -10,10 +10,8 @@ import time
 import re
 import pytest
 import warnings
-from fabric.operations import run, sudo
-from fabric.exceptions import CommandTimeout
-from fabric.context_managers import settings
-from fabric.network import disconnect_all
+import paramiko
+from fabric import Connection
 from alarmageddon.validations.validation import Validation, Priority
 
 import logging
@@ -45,7 +43,7 @@ class SshContext(object):
         """return a string representation of an SshContext object"""
         return "SSH Context {{ User: {0}, Key File: {1} }}"\
             .format(self.user, self.key_file)
-    
+
     def __repr__(self):
         return "{}: {} {}".format(type(self).__name__, self.user, self.key_file)
 
@@ -58,8 +56,7 @@ class SshValidation(Validation):
                  group=None, connection_retries=0,
                  hosts=None):
         """Creates an SshValidation object"""
-        Validation.__init__(self,
-            name, priority, timeout, group=group)
+        Validation.__init__(self, name, priority, timeout, group=group)
         self.context = ssh_context
         if hosts is not None:
             self.hosts = hosts
@@ -82,42 +79,43 @@ class SshValidation(Validation):
         if not self.hosts:
             self.fail("no hosts specified.")
 
+        ssh_kwargs = {"key_filename": self.context.key_file}
+
         #now we can add our default expectation
         self.expectations.append(self._exit_code_expectation)
 
         for host in self.hosts:
-            with settings(warn_only=True,
-                          host_string=host,
-                          user=self.context.user,
-                          key_filename=self.context.key_file):
-                try:
-                    for i in range(self.retries + 1):
-                        try:
-                            self.perform_on_host(host)
-                            break
-                        except CommandTimeout as ex:
-                            #we connected, so don't retry
+            # FIXME: need warn_only
+            with Connection(host=host, user=self.context.user, connect_kwargs=ssh_kwargs) as connection:
+                for i in range(self.retries + 1):
+                    try:
+                        self.perform_on_host(connection)
+                        break
+                    except paramiko.SSHException as ex:
+                        # FIXME: Paramiko doesn't surface a separate sort of exception
+                        # for timeouts like fabric1 did. This probably needs more logic
+                        # to not catch issues that could allow for retrying
+
+                        #we connected, so don't retry
+                        self.fail_on_host(
+                            host,
+                            "SSH Command timed out: {0}".format(str(ex)))
+                    except Exception as ex:
+                        if i >= self.retries:
                             self.fail_on_host(
                                 host,
-                                "SSH Command timed out: {0}".format(str(ex)))
-                        except Exception as ex:
-                            if i >= self.retries:
-                                self.fail_on_host(
-                                    host,
-                                    "SSH Command Exception: {0}"
-                                    .format(str(ex)))
-                                time.sleep(2)
-                finally:
-                    disconnect_all()
+                                "SSH Command Exception: {0}"
+                                .format(str(ex)))
+                            time.sleep(2)
 
     def fail_on_host(self, host, reason):
         """signal failure the test on a particular host"""
         self.fail("[{0}] {1}".format(host, reason))
 
-    def perform_on_host(self, host):
+    def perform_on_host(self, connection):
         """perform a validation against a particular host"""
         self.fail_on_host(
-            host, "perform_on_host must be overriden by derived classes")
+            connection.host, "perform_on_host must be overriden by derived classes")
 
     def add_expectation(self, expectation):
         """Adds an expectation deriving from SshCommandExpectation to the list
@@ -176,21 +174,21 @@ class SshCommandValidation(SshValidation):
         self.use_sudo = use_sudo
         self.expectations = []
 
-    def perform_on_host(self, host):
+    def perform_on_host(self, connection):
         """Runs the SSH Command on a host and checks to see if all expectations
         are met.
 
         """
         if self.use_sudo:
-            output = sudo(self.command,
-                          combine_stderr=True, timeout=self.timeout)
+            output = connection.sudo(self.command,
+                                     combine_stderr=True, timeout=self.timeout)
         else:
-            output = run(self.command,
-                         combine_stderr=True, timeout=self.timeout)
-        logger.info("Got output {} from host {}".format(output, host))
+            output = connection.run(self.command,
+                                    combine_stderr=True, timeout=self.timeout)
+        logger.info("Got output {} from host {}".format(output, connection.host))
         exit_code = output.return_code
         for expectation in self.expectations:
-            expectation.validate(self, host, output, exit_code)
+            expectation.validate(self, connection.host, output, exit_code)
 
 
 class UpstartServiceValidation(SshCommandValidation):
@@ -261,16 +259,16 @@ class LoadAverageValidation(SshValidation):
         self.limits[15]['max'] = max_load
         return self
 
-    def perform_on_host(self, host):
+    def perform_on_host(self, connection):
         """Runs the SSH Command on a host and checks to see if all expectations
         are met.
 
         """
-        (load_1, load_5, load_15) = SshCommands.get_uptime()
+        (load_1, load_5, load_15) = SshCommands.get_uptime(connection)
 
-        self.check(host, 1, load_1)
-        self.check(host, 5, load_5)
-        self.check(host, 15, load_15)
+        self.check(connection.host, 1, load_1)
+        self.check(connection.host, 5, load_5)
+        self.check(connection.host, 15, load_15)
 
     def check(self, host, minutes, load):
         """Make sure that the n-minute load average for the given host is
@@ -426,14 +424,14 @@ class SshCommands(object):
         pass
 
     @staticmethod
-    def get_cpu_count():
+    def get_cpu_count(connection):
         """return the number of processors on the server"""
-        return int(run("grep processor /proc/cpuinfo | wc -l"))
+        return int(connection.run("grep processor /proc/cpuinfo | wc -l"))
 
     @staticmethod
-    def get_uptime():
+    def get_uptime(connection):
         """return the system uptime"""
-        output = run("uptime")
+        output = connection.run("uptime")
         match = UPTIME_REGEX.search(output)
         if match:
             return (float(match.group(1)),

--- a/alarmageddon/validations/ssh.py
+++ b/alarmageddon/validations/ssh.py
@@ -95,12 +95,12 @@ class SshValidation(Validation):
                         try:
                             self.perform_on_host(host)
                             break
-                        except CommandTimeout, ex:
+                        except CommandTimeout as ex:
                             #we connected, so don't retry
                             self.fail_on_host(
                                 host,
                                 "SSH Command timed out: {0}".format(str(ex)))
-                        except Exception, ex:
+                        except Exception as ex:
                             if i >= self.retries:
                                 self.fail_on_host(
                                     host,

--- a/alarmageddon/validations/ssh.py
+++ b/alarmageddon/validations/ssh.py
@@ -86,18 +86,17 @@ class SshValidation(Validation):
         self.expectations.append(self._exit_code_expectation)
 
         for host in self.hosts:
-            # FIXME: need warn_only
             with Connection(host=host, user=self.context.user, connect_kwargs=ssh_kwargs) as connection:
                 for i in range(self.retries + 1):
                     try:
                         self.perform_on_host(connection)
                         break
                     except paramiko.SSHException as ex:
-                        # FIXME: Paramiko doesn't surface a separate sort of exception
+                        # TODO: Paramiko doesn't surface a separate sort of exception
                         # for timeouts like fabric1 did. This probably needs more logic
                         # to not catch issues that could allow for retrying
 
-                        #we connected, so don't retry
+                        # we connected, so don't retry
                         self.fail_on_host(
                             host,
                             "SSH Command timed out: {0}".format(str(ex)))

--- a/alarmageddon/validations/validation.py
+++ b/alarmageddon/validations/validation.py
@@ -160,7 +160,7 @@ class Validation(object):
         if namespace in enriched:
             raise EnrichmentFailure(publisher, self, values)
         enriched[namespace] = {}
-        for key, value in values.iteritems():
+        for key, value in list(values.items()):
             if force_namespace:
                 enriched[namespace][key] = value
             else:

--- a/alarmageddon/validations/validation.py
+++ b/alarmageddon/validations/validation.py
@@ -1,6 +1,6 @@
 """Classes used by all kinds of Validations."""
 
-from exceptions import EnrichmentFailure, ValidationFailure
+from .exceptions import EnrichmentFailure, ValidationFailure
 GLOBAL_NAMESPACE = "GLOBAL"
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
                             "pycrypto==2.6.1",
                             "six==1.13.0",
                             "pika==0.9.13",
-                            "pytest==2.4.0",
-                            "pytest-localserver==0.3.2"],
+                            "pytest==4.6.6",
+                            "pytest-localserver==0.5.0"],
     )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,5 @@ setup(
                             "pycrypto==2.6.1",
                             "six==1.13.0",
                             "pika==1.1.0",
-                            "pytest==4.6.6",
-                            "pytest-localserver==0.5.0"],
+                            "pytest==4.6.6"],
     )

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup
 setup(
         name = "Alarmageddon",
         description = "Automated testing and reporting",
-        version = "1.0.5",
+        version = "1.1.0",
         author = "Tim Stewart, Scott Hellman",
         author_email = "timothy.stewart@pearson.com, scott.hellman@pearson.com",
-        url = "https://github.com/PearsonEducation/Alarmageddon/tarball/1.0.5",
+        url = "https://github.com/PearsonEducation/Alarmageddon/tarball/1.1.0",
         license = "Apache2",
         classifiers=[
             "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
                     "alarmageddon.publishing",
                     "alarmageddon.validations"],
         install_requires = ["fabric==2.5.0",
-                            "Jinja2==2.7.2",
+                            "Jinja2==2.10.1",
                             "requests==2.22.0",
                             "statsd==2.0.3",
                             "colorama==0.3.2",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
         license = "Apache2",
         classifiers=[
             "Development Status :: 5 - Production/Stable",
-            "Programming Language :: Python :: 2 :: Only",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3.4"
             "License :: OSI Approved :: Apache Software License"
             ],
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
                             "colorama==0.3.2",
                             "pycrypto==2.6.1",
                             "six==1.13.0",
-                            "pika==0.9.13",
+                            "pika==1.1.0",
                             "pytest==4.6.6",
                             "pytest-localserver==0.5.0"],
     )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         packages = ['alarmageddon',
                     "alarmageddon.publishing",
                     "alarmageddon.validations"],
-        install_requires = ["fabric==1.10.1",
+        install_requires = ["fabric==2.5.0",
                             "Jinja2==2.7.2",
                             "requests==2.0.0",
                             "statsd==2.0.3",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
                             "statsd==2.0.3",
                             "colorama==0.3.2",
                             "pycrypto==2.6.1",
+                            "six==1.13.0",
                             "pika==0.9.13",
                             "pytest==2.4.0",
                             "pytest-localserver==0.3.2"],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
                     "alarmageddon.validations"],
         install_requires = ["fabric==2.5.0",
                             "Jinja2==2.7.2",
-                            "requests==2.20.0",
+                            "requests==2.22.0",
                             "statsd==2.0.3",
                             "colorama==0.3.2",
                             "pycrypto==2.6.1",

--- a/tests/publishing/test_emailer.py
+++ b/tests/publishing/test_emailer.py
@@ -672,7 +672,7 @@ def test_send(tmpdir, smtpserver, httpserver):
     result = Failure("Check Status Route", http_validator,
                      description=failure_message)
     email_pub.send(result)
-    print(smtpserver.outbox[0])
+    print((smtpserver.outbox[0]))
     assert len(smtpserver.outbox) == 1
     payload = str(smtpserver.outbox[0].get_payload()[0])
     assert payload.split('\n')[5] == "Validation Failure in environment test:"

--- a/tests/publishing/test_http_publisher.py
+++ b/tests/publishing/test_http_publisher.py
@@ -29,7 +29,7 @@ def good_app(environ, start_response):
     response_headers = [('Content-type', 'text/plain')]
     start_response(status, response_headers)
 
-    return ["Success"]
+    return ["Success".encode('utf-8')]
 
 
 @pytest.fixture()
@@ -65,13 +65,13 @@ def failing_app(environ, start_response):
         status = '200 OK'
         response_headers = [('Content-type', 'text/plain')]
         start_response(status, response_headers)
-        return ["Success"]
+        return ["Success".encode('utf-8')]
     else:
         times_to_fail = times_to_fail - 1
         status = '500 Internal Server Error'
         response_headers = [('Content-type', 'text/plain')]
         start_response(status, response_headers)
-        return ["Failure"]
+        return ["Failure".encode('utf-8')]
 
 
 @pytest.fixture()
@@ -106,7 +106,7 @@ def slow_app(environ, start_response):
     response_headers = [('Content-type', 'text/plain')]
     time.sleep(sleep_time)
     start_response(status, response_headers)
-    return ["Success"]
+    return ["Success".encode('utf-8')]
 
 
 @pytest.fixture()

--- a/tests/publishing/test_http_publisher.py
+++ b/tests/publishing/test_http_publisher.py
@@ -32,7 +32,8 @@ def good_app(environ, start_response):
     return ["Success"]
 
 
-def pytest_funcarg__goodserver(request):
+@pytest.fixture()
+def goodserver(request):
     """Defines the testserver funcarg"""
     global request_sent
     request_sent = False
@@ -73,7 +74,8 @@ def failing_app(environ, start_response):
         return ["Failure"]
 
 
-def pytest_funcarg__failingserver(request):
+@pytest.fixture()
+def failingserver(request):
     """Defines the testserver funcarg"""
     global request_sent
     request_sent = False
@@ -107,8 +109,8 @@ def slow_app(environ, start_response):
     return ["Success"]
 
 
-def pytest_funcarg__slowserver(request):
-    """Defines the testserver funcarg"""
+@pytest.fixture()
+def slowserver(request):
     global request_sent
     request_sent = False
 

--- a/tests/publishing/test_pagerduty.py
+++ b/tests/publishing/test_pagerduty.py
@@ -25,7 +25,7 @@ def rate_limiting_app(environ, start_response):
         hits += 1
     response_headers = [('Content-type', 'text/plain')]
     start_response(status, response_headers)
-    return ["Slow down?!\n"]
+    return ["Slow down?!\n".encode('utf-8')]
 
 
 @pytest.fixture()

--- a/tests/publishing/test_pagerduty.py
+++ b/tests/publishing/test_pagerduty.py
@@ -28,7 +28,8 @@ def rate_limiting_app(environ, start_response):
     return ["Slow down?!\n"]
 
 
-def pytest_funcarg__ratelimited(request):
+@pytest.fixture()
+def ratelimited(request):
     """Defines the testserver funcarg"""
     server = WSGIServer(application=rate_limiting_app)
     server.start()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,12 +52,12 @@ def test_config_gets_nested_value(conf):
 
 def test_config_returns_keys(conf):
     c = Config(conf, "prod")
-    assert c.keys() == conf.keys()
+    assert list(c.keys()) == list(conf.keys())
 
 
 def test_config_returns_values(conf):
     c = Config(conf, "prod")
-    assert c.values() == conf.values()
+    assert list(c.values()) == list(conf.values())
 
 
 def test_config_correct_environment(conf):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -82,5 +82,5 @@ def test_reporter_shows_publish_error_info(env):
     reporter.collect(Success("success", Validation("valid")))
     try:
         reporter.report()
-    except ReportingFailure,e:
+    except ReportingFailure as e:
         assert "NOT_HIDDEN" in str(e) 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -21,7 +21,7 @@ def test_str(env):
 def test_reporter_correctly_sends_success(env, valid):
     reporter = env["reporter"]
     publishers = []
-    for i in xrange(10):
+    for i in range(10):
         publishers.append(MockPublisher())
     reporter.publishers = publishers
     reporter.collect(Success("success", Validation("valid")))
@@ -34,7 +34,7 @@ def test_reporter_correctly_sends_success(env, valid):
 def test_reporter_correctly_sends_failures(env, valid):
     reporter = env["reporter"]
     publishers = []
-    for i in xrange(10):
+    for i in range(10):
         publishers.append(MockPublisher())
     reporter.publishers = publishers
     reporter.collect(Failure("failed", Validation("valid"), "why it failed"))
@@ -47,7 +47,7 @@ def test_reporter_correctly_sends_failures(env, valid):
 def test_reporter_correctly_batches(env):
     reporter = env["reporter"]
     publishers = []
-    for i in xrange(10):
+    for i in range(10):
         publishers.append(MockPublisher())
     reporter.publishers = publishers
     reporter.collect(Failure("failed", Validation("valid"), "why it failed"))
@@ -63,7 +63,7 @@ def test_reporter_runs_all_publishers_before_raising(env, valid):
     reporter = env["reporter"]
     bad_pub = 5
     publishers = []
-    for i in xrange(10):
+    for i in range(10):
         publishers.append(MockPublisher())
     publishers[bad_pub] = FailingPublisher()
     reporter.publishers = publishers

--- a/tests/validations/test_cassandra.py
+++ b/tests/validations/test_cassandra.py
@@ -30,7 +30,7 @@ def test_cassandra_success(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = HEALTHY_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
                                          cluster_name=_CLUSTER_NAME)
@@ -58,7 +58,7 @@ def test_cassandra_success_with_question_marks_in_owns(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = QUESTION_MARK_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
                                          cluster_name=_CLUSTER_NAME)
@@ -84,7 +84,7 @@ def test_cassandra_success_without_percent_signs(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = HEALTHY_OUTPUT_WITHOUT_PERCENT_SIGNS
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
                                          cluster_name=_CLUSTER_NAME)
@@ -109,7 +109,7 @@ def test_cassandra_down(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = SERVER_DOWN_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
@@ -135,7 +135,7 @@ def test_cassandra_threshold(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = UNBALANCED_RING_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, owns_threshold=40,
@@ -162,7 +162,7 @@ def test_cassandra_success_with_percent_signs(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = UNHEALTHY_OUTPUT_WITH_PERCENT_SIGNS
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, owns_threshold=40,
@@ -187,7 +187,7 @@ def test_cassandra_node_count(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = MISSING_NODE_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=5,
@@ -200,7 +200,7 @@ def test_no_cassandra(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "Error connecting to remote JMX agent!"
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=5,
@@ -217,7 +217,7 @@ def test_stack_trace(monkeypatch, tmpdir):
     [10.198.10.174] out: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     """
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=4,
@@ -244,7 +244,7 @@ def test_ignore_joining_nodes(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = JOINING_NODE_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=4,
                                          hosts=["127.0.0.1"],
@@ -259,7 +259,7 @@ def test_extra_nodes(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = HEALTHY_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=4,
                                          hosts=["127.0.0.1"],
@@ -429,7 +429,7 @@ def test_zero_ownership_should_not_fail(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = ZERO_OWNERSHIP_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
                                          cluster_name=_CLUSTER_NAME)
@@ -440,7 +440,7 @@ def test_repr(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = ZERO_OWNERSHIP_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
                                          cluster_name=_CLUSTER_NAME)
@@ -451,7 +451,7 @@ def test_str(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = ZERO_OWNERSHIP_OUTPUT
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     str(cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
                                             cluster_name=_CLUSTER_NAME))

--- a/tests/validations/test_cassandra.py
+++ b/tests/validations/test_cassandra.py
@@ -8,6 +8,7 @@ from alarmageddon.validations.cassandra import State
 from alarmageddon.validations.exceptions import ValidationFailure
 import pytest
 from validation_mocks import get_mock_key_file, get_mock_ssh_text
+from fabric import Connection
 
 _CLUSTER_NAME='finance dept'
 
@@ -28,13 +29,11 @@ UN  10.168.4.72    83.75 GB   256     21.2%  dc8cbbdc-d95f-4836-884e-2e12f4adb13
 def test_cassandra_success(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = HEALTHY_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
-                                            cluster_name=_CLUSTER_NAME)
+                                         cluster_name=_CLUSTER_NAME)
      .perform({}))
 
 # For testing this bug: https://issues.apache.org/jira/browse/CASSANDRA-10176
@@ -58,13 +57,11 @@ Note: Non-system keyspaces don't have the same replication settings, effective o
 def test_cassandra_success_with_question_marks_in_owns(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = QUESTION_MARK_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
-                                             cluster_name=_CLUSTER_NAME)
+                                         cluster_name=_CLUSTER_NAME)
      .perform({}))
 
 
@@ -84,16 +81,14 @@ UN  10.168.4.72    83.75 GB   256     21.2   dc8cbbdc-d95f-4836-884e-2e12f4adb13
 
 
 def test_cassandra_success_without_percent_signs(monkeypatch, tmpdir):
-     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
-     text = HEALTHY_OUTPUT_WITHOUT_PERCENT_SIGNS
-     monkeypatch.setattr(ssh, "run",
-                         lambda x: get_mock_ssh_text(text, 0))
-     monkeypatch.setattr(cassandra, "run",
-                         lambda x: get_mock_ssh_text(text, 0))
+    ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
+    text = HEALTHY_OUTPUT_WITHOUT_PERCENT_SIGNS
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
-     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
-                                              cluster_name=_CLUSTER_NAME)
-      .perform({}))
+    (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
+                                         cluster_name=_CLUSTER_NAME)
+     .perform({}))
 
 
 SERVER_DOWN_OUTPUT = """xss =  -ea -javaagent:/usr/share/cassandra/lib/jamm-0.2.5.jar -XX:+UseThreadPriorities -XX:ThreadPriorityPolicy=42 -Xms10240m -Xmx10240m -Xmn2048m -XX:+HeapDumpOnOutOfMemoryError -Xss256k
@@ -113,10 +108,8 @@ DN  10.168.4.72    83.75 GB   256     21.2%  dc8cbbdc-d95f-4836-884e-2e12f4adb13
 def test_cassandra_down(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = SERVER_DOWN_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
@@ -141,15 +134,13 @@ UN  10.168.4.72    83.75 GB   256     11.2%  dc8cbbdc-d95f-4836-884e-2e12f4adb13
 def test_cassandra_threshold(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = UNBALANCED_RING_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, owns_threshold=40,
-                                                 hosts=["127.0.0.1"],
-                                                 cluster_name=_CLUSTER_NAME)
+                                             hosts=["127.0.0.1"],
+                                             cluster_name=_CLUSTER_NAME)
          .perform({}))
 
 
@@ -168,14 +159,12 @@ UN  10.168.4.72    83.75 GB   256     21.2%   dc8cbbdc-d95f-4836-884e-2e12f4adb1
 
 
 def test_cassandra_success_with_percent_signs(monkeypatch, tmpdir):
-     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
-     text = UNHEALTHY_OUTPUT_WITH_PERCENT_SIGNS
-     monkeypatch.setattr(ssh, "run",
-                         lambda x: get_mock_ssh_text(text, 0))
-     monkeypatch.setattr(cassandra, "run",
-                         lambda x: get_mock_ssh_text(text, 0))
+    ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
+    text = UNHEALTHY_OUTPUT_WITH_PERCENT_SIGNS
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
-     with pytest.raises(ValidationFailure):
+    with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, owns_threshold=40,
                                              hosts=["127.0.0.1"])
          .perform({}))
@@ -197,10 +186,8 @@ UN  10.168.4.72    83.75 GB   256     21.2%  dc8cbbdc-d95f-4836-884e-2e12f4adb13
 def test_cassandra_node_count(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = MISSING_NODE_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=5,
@@ -212,10 +199,8 @@ def test_cassandra_node_count(monkeypatch, tmpdir):
 def test_no_cassandra(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "Error connecting to remote JMX agent!"
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=5,
@@ -231,10 +216,8 @@ def test_stack_trace(monkeypatch, tmpdir):
     [10.198.10.174] out: 	at org.apache.cassandra.service.StorageService.getOwnership(StorageService.java:3512)
     [10.198.10.174] out: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     """
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     with pytest.raises(ValidationFailure):
         (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=4,
@@ -260,14 +243,12 @@ UN  10.168.4.72    83.75 GB   256     21.2%  dc8cbbdc-d95f-4836-884e-2e12f4adb13
 def test_ignore_joining_nodes(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = JOINING_NODE_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=4,
-                                             hosts=["127.0.0.1"],
-                                             cluster_name=_CLUSTER_NAME)
+                                         hosts=["127.0.0.1"],
+                                         cluster_name=_CLUSTER_NAME)
      .perform({}))
 
 
@@ -277,14 +258,12 @@ def test_extra_nodes(monkeypatch, tmpdir):
     """
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = HEALTHY_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, number_nodes=4,
-                                             hosts=["127.0.0.1"],
-                                             cluster_name=_CLUSTER_NAME)
+                                         hosts=["127.0.0.1"],
+                                         cluster_name=_CLUSTER_NAME)
      .perform({}))
 
 
@@ -361,7 +340,7 @@ def test_can_parse_nodes_missing_tokens():
 def test_tokens_are_none():
     parser = cassandra.NodetoolStatusParser()
     nodes = parser.parse(OUTPUT_MISSING_TOKENS)
-    assert nodes[0].tokens == None
+    assert nodes[0].tokens is None
 
 
 OUTPUT_MISSING_OWNERSHIP = """xss =  -ea -javaagent:/usr/share/cassandra/lib/jamm-0.2.5.jar -XX:+UseThreadPriorities -XX:ThreadPriorityPolicy=42 -Xms10240m -Xmx10240m -Xmn2048m -XX:+HeapDumpOnOutOfMemoryError -Xss256k
@@ -387,7 +366,7 @@ def test_can_parse_nodes_missing_ownership():
 def test_ownership_is_none():
     parser = cassandra.NodetoolStatusParser()
     nodes = parser.parse(OUTPUT_MISSING_OWNERSHIP)
-    assert nodes[0].owns == None
+    assert nodes[0].owns is None
 
 
 MINIMAL_OUTPUT = """--  Address        Load       Tokens  Owns   Host ID                               Rack
@@ -449,36 +428,30 @@ UN  10.168.4.72    83.75 GB   256     0.0%   dc8cbbdc-d95f-4836-884e-2e12f4adb13
 def test_zero_ownership_should_not_fail(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = ZERO_OWNERSHIP_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
-                                             cluster_name=_CLUSTER_NAME)
+                                         cluster_name=_CLUSTER_NAME)
      .perform({}))
 
 
 def test_repr(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = ZERO_OWNERSHIP_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     (cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
-                                             cluster_name=_CLUSTER_NAME)
+                                         cluster_name=_CLUSTER_NAME)
      .__repr__())
 
 
 def test_str(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = ZERO_OWNERSHIP_OUTPUT
-    monkeypatch.setattr(ssh, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
-    monkeypatch.setattr(cassandra, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     str(cassandra.CassandraStatusValidation(ssh_ctx, hosts=["127.0.0.1"],
-                                             cluster_name=_CLUSTER_NAME))
+                                            cluster_name=_CLUSTER_NAME))

--- a/tests/validations/test_http.py
+++ b/tests/validations/test_http.py
@@ -16,8 +16,8 @@ def slow_app(environ, start_response):
     return ["Slow?!\n"]
 
 
-def pytest_funcarg__slowserver(request):
-    """Defines the testserver funcarg"""
+@pytest.fixture()
+def slowserver(request):
     server = WSGIServer(application=slow_app)
     server.start()
     request.addfinalizer(server.stop)

--- a/tests/validations/test_kafka.py
+++ b/tests/validations/test_kafka.py
@@ -3,6 +3,7 @@ import alarmageddon.validations.kafka as kafka
 from alarmageddon.validations.exceptions import ValidationFailure
 import pytest
 from validation_mocks import get_mock_key_file, get_mock_ssh_text
+from fabric import Connection
 
 _CLUSTER_NAME='widget streams'
 
@@ -10,8 +11,8 @@ def test_kafka_success(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "topic: topic1\tpartition: 0\tleader: 140\treplicas: 140,187,96,99,132\tisr: 140,187,96,99,132\r\ntopic: topic1\tpartition: 1\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic1\tpartition: 2\tleader: 96\treplicas: 96,99,132,140,187\tisr: 96,99,132,140,187\r\ntopic: topic1\tpartition: 3\tleader: 99\treplicas: 99,132,140,187,96\tisr: 99,132,140,187,96\r\ntopic: topic1\tpartition: 4\tleader: 132\treplicas: 132,140,187,96,99\tisr: 132,140,187,96,99\r\ntopic: topic2\tpartition: 0\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 1\tleader: 96\treplicas: 96,99,132,140,187\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 2\tleader: 99\treplicas: 99,132,140,187,96\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 3\tleader: 132\treplicas: 132,140,187,96,99\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 4\tleader: 140\treplicas: 140,187,96,99,132\tisr: 132,96,187,140,99"
 
-    monkeypatch.setattr(kafka, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
 
     (kafka.KafkaStatusValidation(ssh_ctx,
                                  zookeeper_nodes="1.2.3.4:2181",
@@ -23,8 +24,8 @@ def test_kafka_success(monkeypatch, tmpdir):
 def test_kafka_duplicate_partiton(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "topic: topic1\tpartition: 0\tleader: 140\treplicas: 140,187,96,99,132\tisr: 140,187,96,99,132\r\ntopic: topic1\tpartition: 1\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic1\tpartition: 2\tleader: 96\treplicas: 96,99,132,140,187\tisr: 96,99,132,140,187\r\ntopic: topic1\tpartition: 3\tleader: 99\treplicas: 99,132,140,187,96\tisr: 99,132,140,187,96\r\ntopic: topic1\tpartition: 4\tleader: 99\treplicas: 132,140,187,96,99\tisr: 132,140,187,96,99\r\ntopic: topic2\tpartition: 0\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 1\tleader: 96\treplicas: 96,99,132,140,187\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 2\tleader: 99\treplicas: 99,132,140,187,96\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 3\tleader: 132\treplicas: 132,140,187,96,99\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 4\tleader: 140\treplicas: 140,187,96,99,132\tisr: 132,96,187,140,99"
-    monkeypatch.setattr(kafka, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
     with pytest.raises(ValidationFailure):
         (kafka.KafkaStatusValidation(ssh_ctx,
                                      zookeeper_nodes="1.2.3.4:2181",
@@ -36,8 +37,8 @@ def test_kafka_duplicate_partiton(monkeypatch, tmpdir):
 def test_kafka_multiple_duplicate_partition(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "topic: topic1\tpartition: 0\tleader: 140\treplicas: 140,187,96,99,132\tisr: 140,187,96,99,132\r\ntopic: topic1\tpartition: 1\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic1\tpartition: 2\tleader: 96\treplicas: 96,99,132,140,187\tisr: 96,99,132,140,187\r\ntopic: topic1\tpartition: 3\tleader: 99\treplicas: 99,132,140,187,96\tisr: 99,132,140,187,96\r\ntopic: topic1\tpartition: 4\tleader: 99\treplicas: 132,140,187,96,99\tisr: 132,140,187,96,99\r\ntopic: topic2\tpartition: 0\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 1\tleader: 96\treplicas: 96,99,132,140,187\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 2\tleader: 99\treplicas: 99,132,140,187,96\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 3\tleader: 132\treplicas: 132,140,187,96,99\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 4\tleader: 132\treplicas: 140,187,96,99,132\tisr: 132,96,187,140,99"
-    monkeypatch.setattr(kafka, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
     with pytest.raises(ValidationFailure):
         (kafka.KafkaStatusValidation(ssh_ctx,
                                      zookeeper_nodes="1.2.3.4:2181",
@@ -49,8 +50,8 @@ def test_kafka_multiple_duplicate_partition(monkeypatch, tmpdir):
 def test_kafka_command_not_found(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "-bash: /opt/kafka2/bin/kdkd: No such file or directory"
-    monkeypatch.setattr(kafka, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
     with pytest.raises(ValidationFailure):
         (kafka.KafkaStatusValidation(ssh_ctx,
                                      zookeeper_nodes="1.2.3.4:2181",
@@ -71,8 +72,8 @@ def test_kafka_missing_zookeeper(monkeypatch, tmpdir):
     at kafka.admin.ListTopicCommand$.main(ListTopicCommand.scala:43)
     at kafka.admin.ListTopicCommand.main(ListTopicCommand.scala)
     """
-    monkeypatch.setattr(kafka, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
     with pytest.raises(ValidationFailure):
         (kafka.KafkaStatusValidation(ssh_ctx,
                                      zookeeper_nodes="1.2.3.4:2181",
@@ -93,8 +94,8 @@ def test_repr(monkeypatch, tmpdir):
     at kafka.admin.ListTopicCommand$.main(ListTopicCommand.scala:43)
     at kafka.admin.ListTopicCommand.main(ListTopicCommand.scala)
     """
-    monkeypatch.setattr(kafka, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
     v = kafka.KafkaStatusValidation(ssh_ctx,
                                     zookeeper_nodes="1.2.3.4:2181",
                                     hosts=["127.0.0.1"],
@@ -114,8 +115,8 @@ def test_str(monkeypatch, tmpdir):
     at kafka.admin.ListTopicCommand$.main(ListTopicCommand.scala:43)
     at kafka.admin.ListTopicCommand.main(ListTopicCommand.scala)
     """
-    monkeypatch.setattr(kafka, "run",
-                        lambda x: get_mock_ssh_text(text, 0))
+    monkeypatch.setattr(Connection, "run",
+                        lambda self, x: get_mock_ssh_text(text, 0))
     v = kafka.KafkaStatusValidation(ssh_ctx,
                                     zookeeper_nodes="1.2.3.4:2181",
                                     hosts=["127.0.0.1"],

--- a/tests/validations/test_kafka.py
+++ b/tests/validations/test_kafka.py
@@ -12,7 +12,7 @@ def test_kafka_success(monkeypatch, tmpdir):
     text = "topic: topic1\tpartition: 0\tleader: 140\treplicas: 140,187,96,99,132\tisr: 140,187,96,99,132\r\ntopic: topic1\tpartition: 1\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic1\tpartition: 2\tleader: 96\treplicas: 96,99,132,140,187\tisr: 96,99,132,140,187\r\ntopic: topic1\tpartition: 3\tleader: 99\treplicas: 99,132,140,187,96\tisr: 99,132,140,187,96\r\ntopic: topic1\tpartition: 4\tleader: 132\treplicas: 132,140,187,96,99\tisr: 132,140,187,96,99\r\ntopic: topic2\tpartition: 0\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 1\tleader: 96\treplicas: 96,99,132,140,187\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 2\tleader: 99\treplicas: 99,132,140,187,96\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 3\tleader: 132\treplicas: 132,140,187,96,99\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 4\tleader: 140\treplicas: 140,187,96,99,132\tisr: 132,96,187,140,99"
 
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
 
     (kafka.KafkaStatusValidation(ssh_ctx,
                                  zookeeper_nodes="1.2.3.4:2181",
@@ -25,7 +25,7 @@ def test_kafka_duplicate_partiton(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "topic: topic1\tpartition: 0\tleader: 140\treplicas: 140,187,96,99,132\tisr: 140,187,96,99,132\r\ntopic: topic1\tpartition: 1\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic1\tpartition: 2\tleader: 96\treplicas: 96,99,132,140,187\tisr: 96,99,132,140,187\r\ntopic: topic1\tpartition: 3\tleader: 99\treplicas: 99,132,140,187,96\tisr: 99,132,140,187,96\r\ntopic: topic1\tpartition: 4\tleader: 99\treplicas: 132,140,187,96,99\tisr: 132,140,187,96,99\r\ntopic: topic2\tpartition: 0\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 1\tleader: 96\treplicas: 96,99,132,140,187\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 2\tleader: 99\treplicas: 99,132,140,187,96\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 3\tleader: 132\treplicas: 132,140,187,96,99\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 4\tleader: 140\treplicas: 140,187,96,99,132\tisr: 132,96,187,140,99"
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
     with pytest.raises(ValidationFailure):
         (kafka.KafkaStatusValidation(ssh_ctx,
                                      zookeeper_nodes="1.2.3.4:2181",
@@ -38,7 +38,7 @@ def test_kafka_multiple_duplicate_partition(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "topic: topic1\tpartition: 0\tleader: 140\treplicas: 140,187,96,99,132\tisr: 140,187,96,99,132\r\ntopic: topic1\tpartition: 1\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic1\tpartition: 2\tleader: 96\treplicas: 96,99,132,140,187\tisr: 96,99,132,140,187\r\ntopic: topic1\tpartition: 3\tleader: 99\treplicas: 99,132,140,187,96\tisr: 99,132,140,187,96\r\ntopic: topic1\tpartition: 4\tleader: 99\treplicas: 132,140,187,96,99\tisr: 132,140,187,96,99\r\ntopic: topic2\tpartition: 0\tleader: 187\treplicas: 187,96,99,132,140\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 1\tleader: 96\treplicas: 96,99,132,140,187\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 2\tleader: 99\treplicas: 99,132,140,187,96\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 3\tleader: 132\treplicas: 132,140,187,96,99\tisr: 132,96,187,140,99\r\ntopic: topic2\tpartition: 4\tleader: 132\treplicas: 140,187,96,99,132\tisr: 132,96,187,140,99"
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
     with pytest.raises(ValidationFailure):
         (kafka.KafkaStatusValidation(ssh_ctx,
                                      zookeeper_nodes="1.2.3.4:2181",
@@ -51,7 +51,7 @@ def test_kafka_command_not_found(monkeypatch, tmpdir):
     ssh_ctx = ssh.SshContext("ubuntu", get_mock_key_file(tmpdir))
     text = "-bash: /opt/kafka2/bin/kdkd: No such file or directory"
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
     with pytest.raises(ValidationFailure):
         (kafka.KafkaStatusValidation(ssh_ctx,
                                      zookeeper_nodes="1.2.3.4:2181",
@@ -73,7 +73,7 @@ def test_kafka_missing_zookeeper(monkeypatch, tmpdir):
     at kafka.admin.ListTopicCommand.main(ListTopicCommand.scala)
     """
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
     with pytest.raises(ValidationFailure):
         (kafka.KafkaStatusValidation(ssh_ctx,
                                      zookeeper_nodes="1.2.3.4:2181",
@@ -95,7 +95,7 @@ def test_repr(monkeypatch, tmpdir):
     at kafka.admin.ListTopicCommand.main(ListTopicCommand.scala)
     """
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
     v = kafka.KafkaStatusValidation(ssh_ctx,
                                     zookeeper_nodes="1.2.3.4:2181",
                                     hosts=["127.0.0.1"],
@@ -116,7 +116,7 @@ def test_str(monkeypatch, tmpdir):
     at kafka.admin.ListTopicCommand.main(ListTopicCommand.scala)
     """
     monkeypatch.setattr(Connection, "run",
-                        lambda self, x: get_mock_ssh_text(text, 0))
+                        lambda self, x, warn: get_mock_ssh_text(text, 0))
     v = kafka.KafkaStatusValidation(ssh_ctx,
                                     zookeeper_nodes="1.2.3.4:2181",
                                     hosts=["127.0.0.1"],

--- a/tests/validations/test_ssh.py
+++ b/tests/validations/test_ssh.py
@@ -89,7 +89,7 @@ def test_max_load_correctly_formats_failure(monkeypatch, tmpdir):
 
         #we should have raised an error
         assert False
-    except ValidationFailure, e:
+    except ValidationFailure as e:
         #this is a weak check
         assert "{0}" not in str(e)
 

--- a/tests/validations/test_validation.py
+++ b/tests/validations/test_validation.py
@@ -29,7 +29,7 @@ def criticals(request):
     return request.param
 
 
-@pytest.fixture(params=range(5))
+@pytest.fixture(params=list(range(5)))
 def failures(request):
     return request.param
 
@@ -130,10 +130,10 @@ def test_two_enrichments_correctness_independent_of_force(bools):
     valid.enrich(page, page_values, force_namespace=bools)
     pub_data = valid.get_enriched(pub)
     page_data = valid.get_enriched(page)
-    for item in pub_values.items():
-        assert item in pub_data.items()
-    for item in page_values.items():
-        assert item in page_data.items()
+    for item in list(pub_values.items()):
+        assert item in list(pub_data.items())
+    for item in list(page_values.items()):
+        assert item in list(page_data.items())
 
 
 def test_two_enrichments_correctness_independent_of_force_reverse(bools):
@@ -146,10 +146,10 @@ def test_two_enrichments_correctness_independent_of_force_reverse(bools):
     valid.enrich(pub, pub_values, force_namespace=bools)
     pub_data = valid.get_enriched(pub)
     page_data = valid.get_enriched(page)
-    for item in pub_values.items():
-        assert item in pub_data.items()
-    for item in page_values.items():
-        assert item in page_data.items()
+    for item in list(pub_values.items()):
+        assert item in list(pub_data.items())
+    for item in list(page_values.items()):
+        assert item in list(page_data.items())
 
 
 def test_get_empty_enrichment():

--- a/tests/validations/test_validation.py
+++ b/tests/validations/test_validation.py
@@ -6,26 +6,8 @@ from alarmageddon.publishing import pagerduty
 from alarmageddon.validations.exceptions import EnrichmentFailure
 
 
-thresholds = [0, 3, 5]
-
-
 @pytest.fixture(params=[True, False])
 def bools(request):
-    return request.param
-
-
-@pytest.fixture(params=thresholds)
-def lows(request):
-    return request.param
-
-
-@pytest.fixture(params=thresholds)
-def normals(request):
-    return request.param
-
-
-@pytest.fixture(params=thresholds)
-def criticals(request):
     return request.param
 
 
@@ -57,13 +39,15 @@ def test_repr():
     v.__repr__()
 
 
-def test_group_validation_correct_thresholds(lows, normals, criticals):
+def test_group_validation_correct_thresholds():
+    lows, normals, criticals = [0, 3, 5]
     v = GroupValidation("name", "group", low_threshold=lows,
                         normal_threshold=normals, critical_threshold=criticals)
     assert v.low_threshold <= v.normal_threshold <= v.critical_threshold
 
 
 def test_group_validation_handles_failures_correctly(failures, failure_lows):
+    lows, normals, criticals = [0, 3, 5]
     v = GroupValidation("name", "group", low_threshold=failure_lows,
                         normal_threshold=2, critical_threshold=3)
     v._set_priority(failures)

--- a/tests/validations/validation_mocks.py
+++ b/tests/validations/validation_mocks.py
@@ -1,6 +1,16 @@
-from fabric.operations import _AttributeString
 from alarmageddon.validations.validation import Validation
 import time
+
+
+class _AttributeString(str):
+    """
+    Simple string subclass to allow arbitrary attribute access.
+
+    Stolen from fabric1
+    """
+    @property
+    def stdout(self):
+        return str(self)
 
 
 def get_mock_key_file(tmpdir):


### PR DESCRIPTION
Adds support for Python 3 (nominally 3.4+, as that's what fabric supports, but for full disclosure: I only tested against 3.7)

The changes fall into 5 broad categories
1. Automatic changes suggested by the `2to3` utility
2. Fixing logic around checks involving `None` and numbers - Python2 allows this, Python3 does not.
2. Removal of `pytest-localserver`, as in Python 3 our tests using it were sporadically failing and the areas where we used it were easily monkeypatched over.
3. Fabric API changes - namely, there is now a `Connection` object that we pass around.
4. Updating Jinja to address a security vulnerability. Pycrypto also has a vulnerability, but there's no easy resolution to it so I've left that as future work.

The unit tests pass in both Python 2.7 and 3.7. Additionally, I have successfully run one of our real-world Alarmageddon scripts in both 2.7 and 3.7.

I've also bumped the version to 1.1.0. Once this is merged, I think we should immediately tag the commit and publish to pypi.